### PR TITLE
feat(wildberries): 7.6.8001 support + matchAll refactor for big-sale gate

### DIFF
--- a/patches/src/main/kotlin/app/wildberries/patches/ads/RemoveWildberriesAdsPatch.kt
+++ b/patches/src/main/kotlin/app/wildberries/patches/ads/RemoveWildberriesAdsPatch.kt
@@ -20,7 +20,13 @@ private val listBannerWrapperGetters = setOf(
 )
 
 private val mainBannerListGetters = setOf(
+    // `getMainBannersCarousel` is the pre-7.6.8001 name for the main hero slider;
+    // 7.6.8001 renamed/split it into the `getTopSlider*` family. Both are kept so
+    // the top banners are emptied across old and new builds.
     "getMainBannersCarousel",
+    "getTopSlider",
+    "getTopSliderNF",
+    "getTopSliderVF",
     "getMarketingCarousel",
     "getSecondaryBannersCarousel",
     "getTvBanners",

--- a/patches/src/main/kotlin/app/wildberries/patches/ads/RemoveWildberriesAdsPatch.kt
+++ b/patches/src/main/kotlin/app/wildberries/patches/ads/RemoveWildberriesAdsPatch.kt
@@ -1,5 +1,6 @@
 package app.wildberries.patches.ads
 
+import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
@@ -81,8 +82,23 @@ private fun Method.isSuspendObjectMethod(name: String) =
         parameterTypes.lastOrNull()?.toString() == "Lkotlin/coroutines/Continuation;" &&
         hasImplementation()
 
-private fun String.isWildberriesClass() =
-    startsWith("Lru/wildberries/")
+/**
+ * Matches every `ru.wildberries.*` method named `isBigSaleSearchBarEnabled`
+ * returning a boolean. Resolved via `matchAllOrNull` so the patcher locates the
+ * handful of declaring classes directly, instead of us iterating (and materialising
+ * a mutable proxy for) every Wildberries class — the latter exhausted the patcher
+ * heap (see #6). `OrNull` keeps the patch resilient if a future build drops the
+ * method (like it dropped `isVideoBannerInMainCarousel` on 7.6.8001).
+ */
+private object BigSaleSearchBarFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        method.name == "isBigSaleSearchBarEnabled" &&
+            method.implementation != null &&
+            classDef.type.startsWith("Lru/wildberries/")
+    },
+)
 
 private fun String.isBannersUiWrapperClass() =
     startsWith("Lru/wildberries/mainpage/") &&
@@ -505,31 +521,22 @@ val removeWildberriesAdsPatch = bytecodePatch(
                         }
                     }
                 }
-
-                classType.isWildberriesClass() -> {
-                    // This is the catch-all branch for every `ru.wildberries.*` class,
-                    // but only a handful actually declare `isBigSaleSearchBarEnabled`.
-                    // Check the immutable classDef first so we never allocate a mutable
-                    // proxy for the thousands of classes that don't match — materialising
-                    // one per class here is what exhausted the patcher's heap (see #6).
-                    if (classDef.methods.none { it.isBooleanMethod("isBigSaleSearchBarEnabled") }) {
-                        return@classDefForEach
-                    }
-
-                    mutableClassDefBy(classDef).methods.forEach { method ->
-                        if (method.isBooleanMethod("isBigSaleSearchBarEnabled")) {
-                            method.addInstructions(
-                                0,
-                                """
-                                    const/4 v0, 0x0
-                                    return v0
-                                """,
-                            )
-                            patchedBigSaleHeaderMethods++
-                        }
-                    }
-                }
             }
+        }
+
+        // Promo "big sale" header gate: force `isBigSaleSearchBarEnabled` to false on
+        // every declaring class. Resolved by fingerprint instead of a catch-all over
+        // all `ru.wildberries.*` classes so no mutable proxy is allocated for classes
+        // that don't declare it (the catch-all was the #6 OOM source).
+        BigSaleSearchBarFingerprint.matchAllOrNull().orEmpty().forEach { match ->
+            match.method.addInstructions(
+                0,
+                """
+                    const/4 v0, 0x0
+                    return v0
+                """,
+            )
+            patchedBigSaleHeaderMethods++
         }
 
         if (

--- a/patches/src/main/kotlin/app/wildberries/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/wildberries/patches/shared/Constants.kt
@@ -14,6 +14,11 @@ internal object Constants {
         appIconColor = 0xA73AFD,
         targets = listOf(
             AppTarget(
+                version = "7.6.8001",
+                versionCode = 10061041,
+                minSdk = 26,
+            ),
+            AppTarget(
                 version = "7.6.1000-rustore",
                 versionCode = 61016,
                 minSdk = 26,


### PR DESCRIPTION
Adds Wildberries 7.6.8001 support and hardens the ads patch. Builds on the #6 OOM fix (already on `dev`).

## Commits
- **fix(wildberries): cover renamed top-slider banners on 7.6.8001** — WB renamed the main hero carousel getter `getMainBannersCarousel` into a `getTopSlider`/`getTopSliderNF`/`getTopSliderVF` family on the `MainBanners` model. The patch was leaving these untouched, so the top hero slider kept rendering. Added them to `mainBannerListGetters` (old name kept for older builds). Emptied main-banner getters rise 11 → 14 on 7.6.8001; 61016 unchanged (12).
- **bump(wildberries): add 7.6.8001 to supported versions** — versionCode 10061041.
- **perf(wildberries): resolve `isBigSaleSearchBarEnabled` via matchAll, not a catch-all** — replaces the `isWildberriesClass()` catch-all `when` branch (which walked every `ru.wildberries.*` class) with a `Fingerprint` resolved via `matchAllOrNull()`. The patcher now locates only the handful of declaring classes directly — no per-class iteration or mutable-proxy allocation for this surface at all. `matchAllOrNull` (not throwing `matchAll`) keeps the patch resilient if a future build drops the method. Supersedes the #6 pre-filter.

## Verification
Patched on device-grade APKs, both via `--exclusive -e "Remove Wildberries ads"`:

| APK | Heap | Result |
| --- | --- | --- |
| 61016 universal (220k classes) | `-Xmx768m` (the #6 repro heap) | no OOM, promo header = 4 (unchanged), exit 0 |
| 7.6.8001 merged (237k classes) | `-Xmx2g` | 14 list getters, promo header = 2, exit 0 |

Behaviour is byte-identical to the pre-refactor patch on both versions. `isVideoBannerInMainCarousel` and `isNotEmpty`-on-`MainBanners` were removed by WB on 7.6.8001 (nothing left to patch). Codex-reviewed — no correctness issues.