### PR TITLE
bump(ozon): add 19.22.0 support

### DIFF
--- a/patches/src/main/kotlin/app/ozon/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/ozon/patches/shared/Constants.kt
@@ -14,6 +14,11 @@ internal object Constants {
         appIconColor = 0x005BFF,
         targets = listOf(
             AppTarget(
+                version = "19.22.0",
+                versionCode = 2687,
+                minSdk = 26,
+            ),
+            AppTarget(
                 version = "19.16.0",
                 versionCode = 2677,
                 minSdk = 26,


### PR DESCRIPTION
Make Ozon 19.22.0 (versionCode 2687) the primary supported target.

## What
- Add 19.22.0 to the Ozon compatibility targets (now the primary).
- Retain 19.16.0, 18.37.0, and the versionless experimental target for back-compat.

## Why / verification
The `Remove Ozon ads` patch applies cleanly on 19.22.0 with **no source changes** — all fingerprint-based hooks resolve and compile. Verified on device (97PAY11HUX): installs, launches, feed scrolls, no FATAL/VerifyError.

Decompiled the patched dex to confirm every hook survived (some bind methods on 19.22.0 use >16 registers, which produces benign "Invalid register" info warnings as morphe auto-promotes the injected `invoke` to range form):
- `DsAtomsMapper.invoke()` -> returns `Collections.emptyList()` for `generic-warlock`
- `CellV2ViewHolder.bind()` -> collapses `FIRST15` Ozon Select cells
- `AdvBannerV4PlainViewHolder.bind()` -> injected itemView height=0 collapse

Back-compat retained at zero cost (no patch-logic changes).
