### PR TITLE
fix(avito): harden fragile fingerprints against R8 renames

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ads/Fingerprints.kt
@@ -16,13 +16,25 @@ object CommercialBannerLoaderErrorFingerprint : Fingerprint(
     },
 )
 
+/**
+ * Matches the home hero-banner widget converter — the method that turns the network
+ * `HeroBannerWidget` model into the rendered `HeroBannerWidgetItem`. Nulling it stops
+ * the widget from ever building.
+ *
+ * Identified structurally so it survives the per-release minification of the
+ * class/method names: a concrete method in the (stable) `hero_banner/widget/`
+ * package taking a `HeroBannerWidget` and returning a `HeroBannerWidgetItem`. Both
+ * model types keep their real names, and that exact shape is unique to the
+ * converter — the previous pin to the obfuscated class `e`/method `a` rolled on
+ * every R8 build.
+ */
 object HeroBannerWidgetConverterFingerprint : Fingerprint(
-    definingClass = "Lcom/avito/android/hero_banner/widget/e;",
+    definingClass = "Lcom/avito/android/hero_banner/widget/",
     returnType = "Lcom/avito/android/hero_banner/widget/HeroBannerWidgetItem;",
     parameters = listOf(
         "Lcom/avito/android/remote/model/serp/HeroBannerWidget;",
     ),
-    custom = { method, _ -> method.name == "a" },
+    custom = { method, _ -> method.implementation != null },
 )
 
 object HeroBannerToolbarConfigFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
@@ -17,29 +17,32 @@ private fun isAvitoAdjustWrapper(classType: String) =
 // the tracker method is the correct, safe target.)
 object ClickstreamTrackEventFingerprint : Fingerprint(
     returnType = "V",
-    parameters = listOf(
-        "Lcom/avito/android/analytics/o;",
-    ),
     filters = listOf(
         methodCall(
             definingClass = "Ljava/util/concurrent/Executor;",
             name = "execute",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoClickstreamTracker(classDef.type)
+    // The single parameter is the clickstream event, which lives in the
+    // `com.avito.android.analytics` package — anchor on that package rather than the
+    // event class's obfuscated name (it was `analytics/o` but R8 re-letters it).
+    custom = { method, classDef ->
+        isAvitoClickstreamTracker(classDef.type) &&
+            method.parameterTypes.size == 1 &&
+            method.parameterTypes.single().toString().startsWith("Lcom/avito/android/analytics/")
     },
 )
 
 // Fallback (older builds): the clickstream enqueue runnable itself, identified by
-// its ANR log line and the inhouse-transport add() call, when it still lives in a
-// dedicated clickstream class.
+// its (unique) ANR log line and an add() call into the inhouse-transport package,
+// when it still lives in a dedicated clickstream class. The transport class name is
+// matched by package prefix, not its obfuscated leaf (`inhouse_transport/u` rolls).
 object ClickstreamEnqueueRunnableFingerprint : Fingerprint(
     returnType = "V",
     filters = listOf(
         string("Sending event on main thread. May cause ANR"),
         methodCall(
-            definingClass = "Lcom/avito/android/analytics/inhouse_transport/u;",
+            definingClass = "Lcom/avito/android/analytics/inhouse_transport/",
             name = "add",
         ),
     ),

--- a/patches/src/main/kotlin/app/avito/patches/settings/MorpheSettingsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/settings/MorpheSettingsPatch.kt
@@ -101,11 +101,12 @@ val morpheSettingsPatch = bytecodePatch(
 
         // Konveyor adapter-presenter bind hook → MorpheSettings.onBind, which wires
         // the Settings row click and delegates advert binds to the blacklist.
-        // Matched STRUCTURALLY (R8 repackages konveyor per release): the
-        // SimpleAdapterPresenter is the class that has both getItem(int)->ref (the
-        // bound item; `getItem` keeps its name) and a bind method e(viewHolder,
-        // int, List)V. getItem is called on the concrete class so no interface
-        // name is needed.
+        // Matched STRUCTURALLY (R8 repackages konveyor and re-letters its methods per
+        // release): the SimpleAdapterPresenter is the class that has both
+        // getItem(int)->ref (the bound item; `getItem` keeps its name) and a payload
+        // bind method (viewHolder, int, List)V. getItem is called on the concrete
+        // class so no interface name is needed, and the bind method's obfuscated name
+        // is read off the match rather than pinned (it was `e` on 226/227 but rolls).
         var bindHooks = 0
         classDefForEach { classDef ->
             val getItem = classDef.methods.firstOrNull { method ->
@@ -114,20 +115,26 @@ val morpheSettingsPatch = bytecodePatch(
                     method.returnType.startsWith("L")
             } ?: return@classDefForEach
 
+            // The konveyor presenter's bind takes konveyor's own ViewHolder. Exclude
+            // the RecyclerView.Adapter.onBindViewHolder(VH, int, List) override, which
+            // shares the (L, I, List)V shape but is a different method — its name is a
+            // framework override (kept by R8) and its first param is androidx's
+            // RecyclerView$C, so both are stable, non-obfuscated discriminators.
             val bind = classDef.methods.firstOrNull { method ->
-                method.name == "e" &&
-                    method.implementation != null &&
+                method.implementation != null &&
                     method.returnType == "V" &&
+                    method.name != "onBindViewHolder" &&
                     method.parameterTypes.map { it.toString() }.let { params ->
                         params.size == 3 &&
                             params[0].startsWith("L") &&
+                            params[0] != "Landroidx/recyclerview/widget/RecyclerView\$C;" &&
                             params[1] == "I" &&
                             params[2] == "Ljava/util/List;"
                     }
             } ?: return@classDefForEach
 
             mutableClassDefBy(classDef).methods
-                .first { it.name == "e" && it.parameterTypes == bind.parameterTypes }
+                .first { it.name == bind.name && it.parameterTypes == bind.parameterTypes }
                 .addInstructions(
                     0,
                     // Pass the params (p0/p1/p2) straight to the invokes and use only


### PR DESCRIPTION
Harden the four most fragile Avito fingerprints so they survive R8 re-minification instead of silently no-opping (every call site is `methodOrNull?.let`, so a broken name-pin currently fails silently).

## Changes
- **Hero banner widget converter** (`ads/Fingerprints.kt`): match the `hero_banner/widget/` package prefix + `HeroBannerWidget -> HeroBannerWidgetItem` shape instead of the obfuscated class `e` / method `a`.
- **Konveyor settings bind hook** (`settings/MorpheSettingsPatch.kt`): match the `(viewHolder, int, List)V` shape and read the method name off the match instead of pinning `e`; exclude the `RecyclerView.Adapter.onBindViewHolder` override (stable framework name + androidx `RecyclerView$C` first param) so the shape match doesn't pick up two unrelated adapters.
- **Clickstream track-event** (`privacy/Fingerprints.kt`): anchor the single event parameter on the `com.avito.android.analytics` package instead of the obfuscated event class `analytics/o`.
- **Clickstream enqueue-runnable fallback** (`privacy/Fingerprints.kt`): match the `inhouse_transport/` package prefix instead of the obfuscated leaf `inhouse_transport/u`.

## Verification
Cross-version new-vs-old match counts are **identical**, proving the refactor is behavior-preserving:

| version | bind | banner | telemetry |
|---|---|---|---|
| 213.0 | 2 | 1 | 5 |
| 221.0 | 2 | 3 | 5 |
| 226.5 | 2 | 3 | 5 |
| 227.0 | 2 | 3 | 5 |

(banner=1 on 213 because the hero-banner widget predates it.) The earlier draft of the bind-hook change over-matched 4 presenters; the `onBindViewHolder`/`RecyclerView$C` exclusion brings it back to the intended 2.

A patched 227.0 build (Remove ads + Disable telemetry + Block listings + UI tweaks) installs, launches, and opens the Morphe settings screen cleanly with no VerifyError.
