### PR TITLE
refactor(avito): match clickstream event param via Fingerprint.parameters

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
@@ -17,19 +17,21 @@ private fun isAvitoAdjustWrapper(classType: String) =
 // the tracker method is the correct, safe target.)
 object ClickstreamTrackEventFingerprint : Fingerprint(
     returnType = "V",
+    // The single parameter is the clickstream event, which lives in the
+    // `com.avito.android.analytics` package — anchor on that package prefix rather
+    // than the event class's obfuscated name (it was `analytics/o` but R8 re-letters
+    // it). A type without a trailing `;` is matched with startsWith.
+    parameters = listOf(
+        "Lcom/avito/android/analytics/",
+    ),
     filters = listOf(
         methodCall(
             definingClass = "Ljava/util/concurrent/Executor;",
             name = "execute",
         ),
     ),
-    // The single parameter is the clickstream event, which lives in the
-    // `com.avito.android.analytics` package — anchor on that package rather than the
-    // event class's obfuscated name (it was `analytics/o` but R8 re-letters it).
-    custom = { method, classDef ->
-        isAvitoClickstreamTracker(classDef.type) &&
-            method.parameterTypes.size == 1 &&
-            method.parameterTypes.single().toString().startsWith("Lcom/avito/android/analytics/")
+    custom = { _, classDef ->
+        isAvitoClickstreamTracker(classDef.type)
     },
 )
 


### PR DESCRIPTION
Addresses @LisoUseInAIKyrios's review on #11 ([discussion_r3448011810](https://github.com/xob0t/morphe-patches/pull/11#discussion_r3448011810)).

The `ClickstreamTrackEventFingerprint` was doing a manual parameter check in its `custom` block:

```kotlin
custom = { method, classDef ->
    isAvitoClickstreamTracker(classDef.type) &&
        method.parameterTypes.size == 1 &&
        method.parameterTypes.single().toString().startsWith("Lcom/avito/android/analytics/")
},
```

The patcher's `parameters` field already supports partial matching, so this is expressible declaratively:

```kotlin
parameters = listOf(
    "Lcom/avito/android/analytics/",
),
custom = { _, classDef -> isAvitoClickstreamTracker(classDef.type) },
```

**Behaviour-identical** — confirmed against `morphe-patcher` 1.5.0 source:
- `parametersMatch` returns false unless parameter counts are equal → enforces the old `size == 1`.
- A type starting with `L` and **without** a trailing `;` maps to `StringComparisonType.STARTS_WITH` (`typeDeclarationToComparison`) → the old `startsWith` prefix match.

Compiles clean (`:patches:compileKotlin`).