### PR TITLE
refactor: Morphe API hygiene — declarative fingerprints + shared helpers

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ads/Fingerprints.kt
@@ -3,17 +3,12 @@ package app.avito.patches.ads
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.string
 
-private fun isCommercialBannerLoader(classType: String) =
-    classType.startsWith("Lcom/avito/android/advertising/loaders/")
-
 object CommercialBannerLoaderErrorFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/advertising/loaders/",
     returnType = "Lio/reactivex/rxjava3/core/z;",
     filters = listOf(
         string("Not supported SerpBanner type: "),
     ),
-    custom = { _, classDef ->
-        isCommercialBannerLoader(classDef.type)
-    },
 )
 
 /**
@@ -39,7 +34,7 @@ object HeroBannerWidgetConverterFingerprint : Fingerprint(
 
 object HeroBannerToolbarConfigFingerprint : Fingerprint(
     definingClass = "Lcom/avito/android/remote/model/serp/HeroBannerWidget;",
+    name = "getToolbarConfig",
     returnType = "Lcom/avito/android/remote/model/ToolbarConfig;",
     parameters = emptyList(),
-    custom = { method, _ -> method.name == "getToolbarConfig" },
 )

--- a/patches/src/main/kotlin/app/avito/patches/ads/RemoveAdsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ads/RemoveAdsPatch.kt
@@ -5,14 +5,16 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
+import app.shared.childrenNamed
+import app.shared.getOrCreateApplicationMetaData
+import app.shared.methodReferenceOrNull
+import app.shared.removeChildren
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import org.w3c.dom.Element
-import org.w3c.dom.Node
 import java.io.FileNotFoundException
 
 private val adPermissions = setOf(
@@ -107,38 +109,10 @@ private fun nullParametersInstructions(parameterIndexes: List<Int>) =
         }
     }
 
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
 private fun MethodReference.isRxThrowableObservableFactory() =
     definingClass == "Lio/reactivex/rxjava3/core/z;" &&
         parameterTypes.map { it.toString() } == listOf("Ljava/lang/Throwable;") &&
         returnType.startsWith("Lio/reactivex/rxjava3/")
-
-private fun Element.childrenNamed(name: String): List<Element> {
-    val nodes = childNodes
-    return buildList {
-        for (i in 0 until nodes.length) {
-            val node = nodes.item(i)
-            if (node is Element && node.nodeName == name) add(node)
-        }
-    }
-}
-
-private fun Element.childrenNamed(vararg names: String): List<Element> {
-    val acceptedNames = names.toSet()
-    val nodes = childNodes
-    return buildList {
-        for (i in 0 until nodes.length) {
-            val node = nodes.item(i)
-            if (node is Element && node.nodeName in acceptedNames) add(node)
-        }
-    }
-}
-
-private fun Element.removeChildren(nodes: List<Node>) {
-    nodes.forEach(::removeChild)
-}
 
 private fun Element.hideView() {
     setAttribute("android:visibility", "gone")
@@ -152,17 +126,6 @@ private fun Element.hideView() {
     setAttribute("android:clickable", "false")
     setAttribute("android:focusable", "false")
     setAttribute("android:importantForAccessibility", "no")
-}
-
-private fun Element.getOrCreateApplicationMetaData(name: String): Element {
-    childrenNamed("meta-data")
-        .firstOrNull { it.getAttribute("android:name") == name }
-        ?.let { return it }
-
-    val metaData = ownerDocument.createElement("meta-data")
-    metaData.setAttribute("android:name", name)
-    appendChild(metaData)
-    return metaData
 }
 
 private val removeAdResourcesPatch = resourcePatch {

--- a/patches/src/main/kotlin/app/avito/patches/blacklist/BlockListingsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/blacklist/BlockListingsPatch.kt
@@ -8,6 +8,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
+import app.shared.childrenNamed
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import org.w3c.dom.Element
@@ -15,16 +16,6 @@ import org.w3c.dom.Element
 private const val BLACKLIST_CLASS = "Lapp/avito/blacklist/Blacklist;"
 private const val BLOCK_MENU_CLASS = "Lapp/avito/morphe/MorpheBlockMenu;"
 private const val BLACKLIST_ACTIVITY = "app.avito.blacklist.BlacklistActivity"
-
-private fun Element.childrenNamed(name: String): List<Element> {
-    val nodes = childNodes
-    return buildList {
-        for (i in 0 until nodes.length) {
-            val node = nodes.item(i)
-            if (node is Element && node.nodeName == name) add(node)
-        }
-    }
-}
 
 /**
  * Registers the self-contained blacklist management screen

--- a/patches/src/main/kotlin/app/avito/patches/blacklist/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/blacklist/Fingerprints.kt
@@ -20,11 +20,11 @@ private const val EXTENDED_PROFILE = "Lcom/avito/android/remote/model/ExtendedPr
  * it survives the per-release minification of the class/method names.
  */
 object SellerProfileConverterFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/extended_profile/converter/",
     parameters = listOf(STRING, STRING, EXTENDED_PROFILE),
-    custom = { method, classDef ->
-        method.implementation != null &&
-            classDef.type.startsWith("Lcom/avito/android/extended_profile/converter/")
-    },
+    // Only the concrete converter implementation — not an abstract declaration with
+    // the same signature (which has no body to patch).
+    custom = { method, _ -> method.implementation != null },
 )
 
 /**
@@ -69,10 +69,12 @@ object AdvertDetailsToolbarMenuFingerprint : Fingerprint(
  * only `serp/adapter` method with this shape.
  */
 object SerpElementsConverterFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/serp/adapter/",
     returnType = "Ljava/util/ArrayList;",
-    custom = { method, classDef ->
+    // Variable-arity shape (param count differs across releases), so the parameter
+    // constraints stay here rather than in the fixed-arity `parameters` field.
+    custom = { method, _ ->
         method.implementation != null &&
-            classDef.type.startsWith("Lcom/avito/android/serp/adapter/") &&
             method.parameterTypes.map { it.toString() }.let { params ->
                 params.size >= 5 &&
                     params[0] == LIST &&

--- a/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/privacy/Fingerprints.kt
@@ -4,18 +4,13 @@ import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.string
 
-private fun isAvitoClickstreamTracker(classType: String) =
-    classType.startsWith("Lcom/avito/android/analytics/clickstream/")
-
-private fun isAvitoAdjustWrapper(classType: String) =
-    classType.startsWith("Lcom/avito/android/analytics_adjust/")
-
 // Primary (227.0+): ClickStreamEventTrackerImpl.c(event) — the public track-event
 // method that wraps each event in a runnable and dispatches it to an Executor.
 // Neutering it stops clickstream at the source. (On 227 R8 merged the enqueue
 // runnable itself into a shared lambda dispatcher shared with unrelated lambdas, so
 // the tracker method is the correct, safe target.)
 object ClickstreamTrackEventFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics/clickstream/",
     returnType = "V",
     // The single parameter is the clickstream event, which lives in the
     // `com.avito.android.analytics` package — anchor on that package prefix rather
@@ -30,9 +25,6 @@ object ClickstreamTrackEventFingerprint : Fingerprint(
             name = "execute",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoClickstreamTracker(classDef.type)
-    },
 )
 
 // Fallback (older builds): the clickstream enqueue runnable itself, identified by
@@ -40,6 +32,7 @@ object ClickstreamTrackEventFingerprint : Fingerprint(
 // when it still lives in a dedicated clickstream class. The transport class name is
 // matched by package prefix, not its obfuscated leaf (`inhouse_transport/u` rolls).
 object ClickstreamEnqueueRunnableFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics/clickstream/",
     returnType = "V",
     filters = listOf(
         string("Sending event on main thread. May cause ANR"),
@@ -48,12 +41,10 @@ object ClickstreamEnqueueRunnableFingerprint : Fingerprint(
             name = "add",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoClickstreamTracker(classDef.type)
-    },
 )
 
 object AdjustInitFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics_adjust/",
     returnType = "V",
     filters = listOf(
         methodCall(
@@ -62,12 +53,10 @@ object AdjustInitFingerprint : Fingerprint(
         ),
         string("Adjust initialized"),
     ),
-    custom = { _, classDef ->
-        isAvitoAdjustWrapper(classDef.type)
-    },
 )
 
 object AdjustTrackEventFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics_adjust/",
     returnType = "V",
     parameters = listOf(
         "Lcom/adjust/sdk/AdjustEvent;",
@@ -78,12 +67,10 @@ object AdjustTrackEventFingerprint : Fingerprint(
             name = "trackEvent",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoAdjustWrapper(classDef.type)
-    },
 )
 
 object AdjustUserIdFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics_adjust/",
     returnType = "V",
     parameters = listOf(
         "Ljava/lang/String;",
@@ -98,12 +85,10 @@ object AdjustUserIdFingerprint : Fingerprint(
             name = "removeGlobalPartnerParameter",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoAdjustWrapper(classDef.type)
-    },
 )
 
 object AdjustPushTokenFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/analytics_adjust/",
     returnType = "V",
     parameters = listOf(
         "Ljava/lang/String;",
@@ -114,7 +99,4 @@ object AdjustPushTokenFingerprint : Fingerprint(
             name = "setPushToken",
         ),
     ),
-    custom = { _, classDef ->
-        isAvitoAdjustWrapper(classDef.type)
-    },
 )

--- a/patches/src/main/kotlin/app/avito/patches/settings/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/settings/Fingerprints.kt
@@ -11,12 +11,10 @@ import app.morphe.patcher.string
  * returned list.
  */
 object SettingsListBuilderFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/settings/",
     returnType = "Ljava/util/ArrayList;",
     filters = listOf(
         string("notifications"),
         string("helpCenter"),
     ),
-    custom = { _, classDef ->
-        classDef.type.startsWith("Lcom/avito/android/settings/")
-    },
 )

--- a/patches/src/main/kotlin/app/avito/patches/settings/MorpheSettingsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/settings/MorpheSettingsPatch.kt
@@ -5,22 +5,13 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
+import app.shared.childrenNamed
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import org.w3c.dom.Element
 
 private const val MORPHE_SETTINGS_CLASS = "Lapp/avito/morphe/MorpheSettings;"
 private const val MORPHE_SETTINGS_ACTIVITY = "app.avito.morphe.MorpheSettingsActivity"
-
-private fun Element.childrenNamed(name: String): List<Element> {
-    val nodes = childNodes
-    return buildList {
-        for (i in 0 until nodes.length) {
-            val node = nodes.item(i)
-            if (node is Element && node.nodeName == name) add(node)
-        }
-    }
-}
 
 /**
  * Registers the generic Morphe settings screen ([MORPHE_SETTINGS_ACTIVITY],

--- a/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
@@ -1,7 +1,7 @@
 package app.avito.patches.ui
 
 import app.morphe.patcher.Fingerprint
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import app.morphe.patcher.fieldAccess
 
 /**
  * Matches the Favorites presenter method that consumes the assembled tab list and
@@ -11,18 +11,16 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
  * `A.a` is bypassed by a feature flag), so hooking here drops the subscriptions
  * tab regardless of how the list was built. Identified by its stable shape: a
  * `void` method in `com.avito.android.user_favorites` taking a single `List` whose
- * body references the (non-obfuscated) `UserFavoritesTabsRenderMode` — unique to
+ * body reads the (non-obfuscated) `UserFavoritesTabsRenderMode` enum — unique to
  * this method.
  */
 object FavoritesTabsConsumerFingerprint : Fingerprint(
     definingClass = "Lcom/avito/android/user_favorites/",
     returnType = "V",
     parameters = listOf("Ljava/util/List;"),
-    custom = { method, _ ->
-        method.implementation != null &&
-            method.implementation!!.instructions.any { instruction ->
-                val reference = (instruction as? ReferenceInstruction)?.reference ?: return@any false
-                reference.toString().contains("UserFavoritesTabsRenderMode")
-            }
-    },
+    // The method reads UserFavoritesTabsRenderMode enum values; match a field access
+    // of that (non-obfuscated) type rather than scanning every instruction's reference.
+    filters = listOf(
+        fieldAccess(type = "Lcom/avito/android/user_favorites/UserFavoritesTabsRenderMode;"),
+    ),
 )

--- a/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
@@ -15,11 +15,11 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
  * this method.
  */
 object FavoritesTabsConsumerFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/user_favorites/",
     returnType = "V",
     parameters = listOf("Ljava/util/List;"),
-    custom = { method, classDef ->
+    custom = { method, _ ->
         method.implementation != null &&
-            classDef.type.startsWith("Lcom/avito/android/user_favorites/") &&
             method.implementation!!.instructions.any { instruction ->
                 val reference = (instruction as? ReferenceInstruction)?.reference ?: return@any false
                 reference.toString().contains("UserFavoritesTabsRenderMode")

--- a/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
@@ -12,10 +12,8 @@ import app.morphe.patcher.util.smali.ExternalLabel
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.reference.FieldReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private const val NAVIGATION_TAB = "Lcom/avito/android/bottom_navigation/NavigationTab;"
 private const val BOTTOM_NAVIGATION_SPACE = "Lcom/avito/android/bottom_navigation/space/BottomNavigationSpace;"
@@ -28,12 +26,6 @@ private const val VISUAL_RUBRICATOR_ELEMENT =
 private const val INTEGER = "Ljava/lang/Integer;"
 
 private val AVI_TAB_NAMES = setOf("AI_ASSISTANT", "AI_ASSISTANT_SELLER")
-
-private fun Instruction.fieldReferenceOrNull(): FieldReference? =
-    (this as? ReferenceInstruction)?.reference as? FieldReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun Method.usesBottomNavigationSpace() =
     parameterTypes.any { it.toString() == BOTTOM_NAVIGATION_SPACE }

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAdjustPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAdjustPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableAdjustPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAppMetricaPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAppMetricaPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 private val disableAppMetricaManifestPatch = resourcePatch {
     execute {

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAppsFlyerPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableAppsFlyerPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableAppsFlyerPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableFirebaseTelemetryPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableFirebaseTelemetryPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableFirebaseTelemetryPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableGoogleAnalyticsPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableGoogleAnalyticsPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableGoogleAnalyticsPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableMyTrackerPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableMyTrackerPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableMyTrackerPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableRuStoreMetricsPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableRuStoreMetricsPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 @Suppress("unused")
 val disableRuStoreMetricsPatch = resourcePatch(

--- a/patches/src/main/kotlin/app/privacy/patches/analytics/DisableSentryTelemetryPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/analytics/DisableSentryTelemetryPatch.kt
@@ -2,6 +2,7 @@ package app.privacy.patches.analytics
 
 import app.morphe.patcher.patch.resourcePatch
 import org.w3c.dom.Element
+import app.shared.*
 
 /*
  * Adapted from ReVanced:

--- a/patches/src/main/kotlin/app/privacy/patches/emulator/SpoofEmulatorStatusPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/emulator/SpoofEmulatorStatusPatch.kt
@@ -7,12 +7,11 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private val EMULATOR_INDICATOR_STRINGS = setOf(
     "/dev/qemu_pipe",
@@ -97,15 +96,6 @@ private val EMULATOR_PACKAGE_NAMES = setOf(
     "com.nox.mopen.app",
     "com.vphone.launcher",
 )
-
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
-private fun Instruction.fieldReferenceOrNull(): FieldReference? =
-    (this as? ReferenceInstruction)?.reference as? FieldReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun Instruction.registers(): List<Int> =
     when (this) {

--- a/patches/src/main/kotlin/app/privacy/patches/security/DisableFreeRaspPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/security/DisableFreeRaspPatch.kt
@@ -6,18 +6,11 @@ import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private const val CONTEXT = "Landroid/content/Context;"
 private const val STRING = "Ljava/lang/String;"
-
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun Method.hasFreeRaspStartContext(): Boolean {
     val instructions = instructionsOrNull?.toList() ?: return false

--- a/patches/src/main/kotlin/app/privacy/patches/usb/SpoofUsbDebuggingStatusPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/usb/SpoofUsbDebuggingStatusPatch.kt
@@ -7,11 +7,10 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private val USB_DEBUG_INTEGER_SETTINGS = setOf(
     "adb_enabled",
@@ -33,12 +32,6 @@ private fun zeroConstant(register: Int) =
     } else {
         "const/16 v$register, 0x0"
     }
-
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun Instruction.registers(): List<Int> =
     when (this) {

--- a/patches/src/main/kotlin/app/privacy/patches/vpn/SpoofVpnStatusPatch.kt
+++ b/patches/src/main/kotlin/app/privacy/patches/vpn/SpoofVpnStatusPatch.kt
@@ -7,12 +7,11 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private const val TRANSPORT_VPN = 4
 private const val NET_CAPABILITY_NOT_VPN = 15
@@ -24,12 +23,6 @@ private const val NETWORK_REQUEST = "Landroid/net/NetworkRequest;"
 private const val NETWORK_CALLBACK = "Landroid/net/ConnectivityManager\$NetworkCallback;"
 private const val LINK_PROPERTIES = "Landroid/net/LinkProperties;"
 private const val NETWORK_INTERFACE = "Ljava/net/NetworkInterface;"
-
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun MethodReference.isNetworkCapabilitiesHasTransport() =
     definingClass == NETWORK_CAPABILITIES &&

--- a/patches/src/main/kotlin/app/shared/InstructionHelpers.kt
+++ b/patches/src/main/kotlin/app/shared/InstructionHelpers.kt
@@ -1,0 +1,24 @@
+package app.shared
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+
+/**
+ * Shared reference-decoding helpers for the structural instruction scans used by
+ * several patches. The patcher's fingerprint filters / `Match` accessors cover the
+ * common case, but the manual backward/forward register-window scans (R8-resilient
+ * dataflow gating) still need to decode a single instruction's reference by hand —
+ * these are that decode, kept here once instead of copied into each patch.
+ */
+
+internal fun Instruction.methodReferenceOrNull(): MethodReference? =
+    (this as? ReferenceInstruction)?.reference as? MethodReference
+
+internal fun Instruction.fieldReferenceOrNull(): FieldReference? =
+    (this as? ReferenceInstruction)?.reference as? FieldReference
+
+internal fun Instruction.stringReferenceOrNull(): String? =
+    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string

--- a/patches/src/main/kotlin/app/shared/ManifestXml.kt
+++ b/patches/src/main/kotlin/app/shared/ManifestXml.kt
@@ -1,7 +1,15 @@
-package app.privacy.patches.analytics
+package app.shared
 
 import org.w3c.dom.Element
 import org.w3c.dom.Node
+
+/**
+ * Shared DOM ([org.w3c.dom.Element]) helpers for editing AndroidManifest.xml from
+ * resource patches. The patcher's own `AndroidManifestHelper` operates on binary
+ * `ResXmlElement`, not the `org.w3c.dom` tree returned by `document(...)`, so these
+ * convenience helpers are the project's own — kept here once instead of copied into
+ * each patch.
+ */
 
 internal fun Element.childrenNamed(name: String): List<Element> {
     val nodes = childNodes

--- a/patches/src/main/kotlin/app/tbank/patches/antitamper/BypassAntiTamperPatch.kt
+++ b/patches/src/main/kotlin/app/tbank/patches/antitamper/BypassAntiTamperPatch.kt
@@ -6,10 +6,9 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.tbank.patches.shared.Constants.COMPATIBILITY_TBANK
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import app.shared.*
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private const val RASP_EXECUTOR = "Lcom/t/core/miaf/ndk/Executor;"
 private const val SYSTEM = "Ljava/lang/System;"
@@ -30,12 +29,6 @@ private val TAMPER_FLAG_NAMES = setOf(
 )
 
 // Helpers.
-
-private fun Instruction.methodReferenceOrNull(): MethodReference? =
-    (this as? ReferenceInstruction)?.reference as? MethodReference
-
-private fun Instruction.stringReferenceOrNull(): String? =
-    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
 
 private fun MethodReference.isRaspExec() =
     definingClass == RASP_EXECUTOR &&


### PR DESCRIPTION
Consolidated refactor pass to lean on Morphe's declarative API and remove duplication. No behaviour changes; verified on device.

### 1. Declarative `Fingerprint` fields over `custom` blocks (12 fingerprints)
- `classDef.type.startsWith(...)` → `definingClass`; `method.name == ...` → `name`.
- 9 drop `custom` entirely (+3 unused helper funcs removed); 3 keep a trimmed `custom` for the irreducible part. `definingClass` also lets the resolver prune the class search space up front.

### 2. Favorites tab: `fieldAccess` filter over an instruction-scan `custom` (maintainer request)
- `FavoritesTabsConsumerFingerprint` scanned every instruction's reference for `UserFavoritesTabsRenderMode`. Decompiling 227 shows the target `O.b(List)V` reads that (non-obfuscated) enum via field accesses, so: `filters = listOf(fieldAccess(type = "L…/UserFavoritesTabsRenderMode;"))`. (A `string()` filter wouldn't work — it only matches const-string opcodes; this is a reference instruction.)

### 3. De-duplicate shared helpers into `app.shared`
- DOM manifest helpers (`childrenNamed`, `getOrCreateApplicationMetaData`, `disableComponents*`, …) — were copied across 4 avito patches + the analytics copy → `ManifestXml.kt`.
- Instruction reference decoders (`methodReferenceOrNull`/`fieldReferenceOrNull`/`stringReferenceOrNull`) — copied across 7 avito/privacy/tbank patches → `InstructionHelpers.kt`. (The patcher provides no DOM/register-flow helpers, so these stay the project's own — just de-duplicated. Per-patch `registers()`/`writesRegister()` differ by opcode set and stay local.)

### Verification (227.0, Pixel 3a)
- All affected patches apply with **0 failures**: Block listings, Morphe settings, Remove ads (10+4 layouts / 3 banners / 2 teasers), UI tweaks (`gated the Favorites subscriptions tab in …user_favorites/O;->b`), Disable telemetry (`disabled 5/5`).
- `SerpElementsConverter` (variable-arity) resolves on **213.0 / 226.5 / 227.0**.
- Patched build installs and boots clean (no VerifyError).
- `:patches:compileKotlin` clean.