### PR TITLE
feat(avito): expand offer descriptions by default

### DIFF
--- a/extensions/extension/src/main/java/app/avito/morphe/MorpheSettings.java
+++ b/extensions/extension/src/main/java/app/avito/morphe/MorpheSettings.java
@@ -134,6 +134,18 @@ public final class MorpheSettings {
     }
 
     /**
+     * Gate for the "expand description by default" tweak, injected at the entry of
+     * {@code ExpandablePanelLayout.setCollapsedLineCount(Integer)} — the single
+     * threshold every "Читать далее" description panel funnels through. While the
+     * toggle is on it returns an effectively-unlimited line count, so the text shows
+     * in full and the read-more handle stays hidden; off → the value unchanged (stock
+     * collapse). Re-evaluated on each (re)bind, so no restart is required.
+     */
+    public static Integer expandedLineCount(Integer count) {
+        return isEnabled("avito_expand_description", true) ? Integer.valueOf(Integer.MAX_VALUE) : count;
+    }
+
+    /**
      * Gate for the "single-row home categories" feature, injected into the
      * rubricator tile's getRowLine(): when on, every tile reports row 1 so the
      * category rubricator collapses to one row. Off → stock (two rows).

--- a/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
@@ -24,3 +24,19 @@ object FavoritesTabsConsumerFingerprint : Fingerprint(
         fieldAccess(type = "Lcom/avito/android/user_favorites/UserFavoritesTabsRenderMode;"),
     ),
 )
+
+/**
+ * Matches `ExpandablePanelLayout.setCollapsedLineCount(Integer)` — the single setter
+ * every "Читать далее" description block funnels its collapsed-line threshold through
+ * (the offer description, plus hotel/gig/own-advert/branding variants). Forcing that
+ * threshold high makes the text render in full and keeps the read-more handle hidden.
+ *
+ * The class name is kept (the widget is inflated from layout XML, so R8 can't rename
+ * it), and the `(Integer)V` signature is unique within the class — so we match
+ * structurally and don't rely on the method name surviving minification.
+ */
+object ExpandablePanelCollapsedLinesFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/util/ExpandablePanelLayout;",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/Integer;"),
+)

--- a/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
@@ -44,6 +44,8 @@ private fun Method.hasFieldReference(fields: Set<String>): Boolean =
  *  - **Hide the "Подписки" tab** on the Избранное (Favorites) screen.
  *  - **Hide the installments (Рассрочка)** surfaces and the **"Спросите у
  *    продавца"** block on offer pages.
+ *  - **Expand descriptions by default** so the full text shows without tapping
+ *    "Читать далее".
  *  - **Hide the Avi assistant tab** in the bottom navigation bar.
  *
  * Each tweak is applied independently and degrades gracefully: if the target
@@ -55,7 +57,8 @@ val uiTweaksPatch = bytecodePatch(
     name = "UI tweaks",
     description = "Optional interface tweaks, each toggleable in Настройки Morphe: single-row home " +
         "categories, hide the \"Подписки\" tab in Избранное, hide installments (Рассрочка) and the " +
-        "\"Спросите у продавца\" block on offers, and hide the Avi assistant tab in the bottom navigation.",
+        "\"Спросите у продавца\" block on offers, expand descriptions by default (no \"Читать далее\"), " +
+        "and hide the Avi assistant tab in the bottom navigation.",
     default = false,
 ) {
     compatibleWith(COMPATIBILITY_AVITO)
@@ -199,6 +202,32 @@ val uiTweaksPatch = bytecodePatch(
             title = "Скрыть «Спросите у продавца»",
             summary = "Убрать блок с вопросами продавцу",
         )
+
+        // --- Expand offer descriptions by default -------------------------------
+        // Every "Читать далее" description block hands its collapse threshold to
+        // ExpandablePanelLayout.setCollapsedLineCount(Integer). Route that count
+        // through expandedLineCount(): when the toggle is on it returns an
+        // effectively-unlimited value, so the panel never truncates and the
+        // read-more handle stays hidden. Re-evaluated on each (re)bind — no restart.
+        val collapsedLinesSetter = ExpandablePanelCollapsedLinesFingerprint.methodOrNull
+        if (collapsedLinesSetter == null) {
+            println("UI tweaks: ExpandablePanelLayout.setCollapsedLineCount not found; expand description skipped")
+        } else {
+            collapsedLinesSetter.addInstructions(
+                0,
+                """
+                    invoke-static {p1}, $MORPHE_SETTINGS_CLASS->expandedLineCount($INTEGER)$INTEGER
+                    move-result-object p1
+                """,
+            )
+            MorpheSettingsRegistry.addSwitch(
+                key = "avito_expand_description",
+                title = "Разворачивать описание",
+                summary = "Показывать полное описание объявления без кнопки «Читать далее»",
+                default = true,
+            )
+            println("UI tweaks: gated ExpandablePanelLayout collapsed-line count behind avito_expand_description.")
+        }
 
         // --- Hide the Avi assistant tab in the bottom navigation ----------------
         // The Avi tab doesn't exist on every release (e.g. 227.0); when absent the


### PR DESCRIPTION
## What

Adds a UI tweak that renders the full offer description by default, so you no longer have to tap **«Читать далее»** to read it.

New toggle in **Настройки Morphe**: **«Разворачивать описание»** (`avito_expand_description`, default **on**). Turning it off restores stock collapse — no rebuild or restart needed (re-evaluated on each bind).

## How

Every "Читать далее" block funnels its collapse threshold through `ExpandablePanelLayout.setCollapsedLineCount(Integer)`. The hook routes that count through `MorpheSettings.expandedLineCount()` at method entry: when the toggle is on it returns `Integer.MAX_VALUE`, so the measure step never sees `lineCount > collapsedLines` → full text shown, read-more handle hidden.

One choke point covers every expandable description (offer + hotel/gig/own-advert/branding) instead of several fragile per-screen hooks.

## Robustness

`ExpandablePanelCollapsedLinesFingerprint` matches **structurally**, not by method name:
- `definingClass` is exact but the class name is **kept** (the widget is inflated from layout XML, so R8 can't rename it).
- The `(Integer)V` signature is **unique** within the class.

So it survives R8 renames. Verified the hook lands correctly on both **213.0** (oldest supported) and **227.0** (newest) despite different obfuscation maps; degrades gracefully (skips, never aborts) on any version where the setter is absent.

## Files
- `MorpheSettings.java` — `expandedLineCount(Integer)` gate
- `ui/Fingerprints.kt` — `ExpandablePanelCollapsedLinesFingerprint`
- `ui/UiTweaksPatch.kt` — hook + toggle registration + docs

## Test
- Build ✅ · patches 213 + 227 ✅ · bytecode-verified both ends ✅
- Full daily-driver 227 build installs and launches clean on device