### PR TITLE
feat(ads): make ad surfaces mandatory so version drift fails the patch

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/ads/RemoveAdsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ads/RemoveAdsPatch.kt
@@ -3,6 +3,7 @@ package app.avito.patches.ads
 import app.avito.patches.shared.Constants.COMPATIBILITY_AVITO
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.shared.childrenNamed
@@ -161,8 +162,13 @@ private val removeAdResourcesPatch = resourcePatch {
             }
         }
 
+        // Every ad/banner surface is mandatory: if an expected layout (or the ad
+        // element inside it) is gone, the app changed and the patch is stale, so we
+        // fail loudly instead of silently shipping ads. Missing surfaces are collected
+        // and reported together. (Older builds that lack some surfaces are out of
+        // scope — we only patch current releases.)
+        val missing = mutableListOf<String>()
         var hiddenLayouts = 0
-        var missingLayouts = 0
 
         (hiddenRewardLayouts + hiddenAdLayouts).forEach { path ->
             try {
@@ -171,7 +177,7 @@ private val removeAdResourcesPatch = resourcePatch {
                 }
                 hiddenLayouts++
             } catch (_: FileNotFoundException) {
-                missingLayouts++
+                missing += path
             }
         }
 
@@ -180,35 +186,49 @@ private val removeAdResourcesPatch = resourcePatch {
             try {
                 document(path).use { document ->
                     val root = document.documentElement
-                    if (root.nodeName == "merge") {
-                        root.childrenNamed(
+                    val hidden = if (root.nodeName == "merge") {
+                        val banners = root.childrenNamed(
                             "androidx.constraintlayout.widget.ConstraintLayout",
                             "com.google.android.material.appbar.CollapsingToolbarLayout",
-                        ).forEach(Element::hideView)
+                        )
+                        banners.forEach(Element::hideView)
+                        banners.isNotEmpty()
                     } else {
                         root.hideView()
+                        true
                     }
+                    if (hidden) hiddenHomeBannerLayoutsCount++ else missing += "$path (no banner view)"
                 }
-                hiddenHomeBannerLayoutsCount++
             } catch (_: FileNotFoundException) {
-                missingLayouts++
+                missing += path
             }
         }
 
         try {
             document("res/layout/bx_content_fragment.xml").use { document ->
-                document.documentElement.childrenNamed("FrameLayout")
+                val shadows = document.documentElement.childrenNamed("FrameLayout")
                     .filter { it.getAttribute("android:id") == "@id/hero_banner_shadow" }
-                    .forEach(Element::hideView)
+                shadows.forEach(Element::hideView)
+                if (shadows.isNotEmpty()) {
+                    hiddenHomeBannerLayoutsCount++
+                } else {
+                    missing += "res/layout/bx_content_fragment.xml (@id/hero_banner_shadow)"
+                }
             }
-            hiddenHomeBannerLayoutsCount++
         } catch (_: FileNotFoundException) {
-            missingLayouts++
+            missing += "res/layout/bx_content_fragment.xml"
+        }
+
+        if (missing.isNotEmpty()) {
+            throw PatchException(
+                "Remove ads: ${missing.size} expected ad/banner surface(s) not found — " +
+                    "the app layout changed, update RemoveAdsPatch: ${missing.joinToString(", ")}",
+            )
         }
 
         println(
             "Remove ads: hid $hiddenLayouts ad/reward layouts and " +
-                "$hiddenHomeBannerLayoutsCount home banner layouts, skipped $missingLayouts missing layouts.",
+                "$hiddenHomeBannerLayoutsCount home banner layouts (all required surfaces present).",
         )
     }
 }
@@ -223,35 +243,28 @@ val removeAdsPatch = bytecodePatch(
     dependsOn(removeAdResourcesPatch)
 
     execute {
-        // Each ad surface is patched independently and tolerates absence: ad
-        // entry points come and go across releases (e.g. the hero banner widget
-        // doesn't exist on older builds), so a missing fingerprint skips that
-        // surface instead of aborting the whole patch.
-        var bannerSurfaces = 0
+        // Every ad surface is mandatory: ad entry points are core to the app, so a
+        // fingerprint that no longer resolves means the app changed and the patch is
+        // stale — fail loudly instead of silently shipping ads. (Older builds missing
+        // a surface are out of scope; we only patch current releases.)
 
         // Home hero banner widget: null the converter so the widget never builds.
-        HeroBannerWidgetConverterFingerprint.methodOrNull?.let { method ->
-            method.addInstructions(
-                0,
-                """
-                    const/4 v0, 0x0
-                    return-object v0
-                """,
-            )
-            bannerSurfaces++
-        }
+        HeroBannerWidgetConverterFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return-object v0
+            """,
+        )
 
         // Hero banner toolbar config: return null so no banner toolbar is shown.
-        HeroBannerToolbarConfigFingerprint.methodOrNull?.let { method ->
-            method.addInstructions(
-                0,
-                """
-                    const/4 p0, 0x0
-                    return-object p0
-                """,
-            )
-            bannerSurfaces++
-        }
+        HeroBannerToolbarConfigFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 p0, 0x0
+                return-object p0
+            """,
+        )
 
         var galleryTeaserConvertersPatched = 0
         classDefForEach { classDef ->
@@ -269,11 +282,16 @@ val removeAdsPatch = bytecodePatch(
                 )
             galleryTeaserConvertersPatched++
         }
+        if (galleryTeaserConvertersPatched == 0) {
+            throw PatchException(
+                "Remove ads: no gallery Beduin teaser converter found — the converter " +
+                    "signature changed, update isCarouselGalleryConverter() for this version.",
+            )
+        }
 
         // Commercial banner loader: emit an Rx error instead of loading a banner.
-        // Skip the surface if the loader (or its Rx error factory) isn't present.
-        val commercialBannerLoaderMethod = CommercialBannerLoaderErrorFingerprint.methodOrNull
-        val rxErrorFactory = commercialBannerLoaderMethod?.instructionsOrNull
+        val commercialBannerLoaderMethod = CommercialBannerLoaderErrorFingerprint.method
+        val rxErrorFactory = commercialBannerLoaderMethod.instructionsOrNull
             ?.firstNotNullOfOrNull { instruction ->
                 if (instruction.opcode !in setOf(Opcode.INVOKE_STATIC, Opcode.INVOKE_STATIC_RANGE)) {
                     return@firstNotNullOfOrNull null
@@ -282,23 +300,22 @@ val removeAdsPatch = bytecodePatch(
                 instruction.methodReferenceOrNull()
                     ?.takeIf { it.isRxThrowableObservableFactory() }
             }
-        if (commercialBannerLoaderMethod != null && rxErrorFactory != null) {
-            commercialBannerLoaderMethod.addInstructions(
-                0,
-                """
-                    new-instance v0, Ljava/lang/RuntimeException;
-                    const-string v1, "Avito ads disabled"
-                    invoke-direct {v0, v1}, Ljava/lang/RuntimeException;-><init>(Ljava/lang/String;)V
-                    invoke-static {v0}, ${rxErrorFactory.definingClass}->${rxErrorFactory.name}(Ljava/lang/Throwable;)${rxErrorFactory.returnType}
-                    move-result-object v0
-                    return-object v0
-                """,
+            ?: throw PatchException(
+                "Remove ads: commercial banner loader matched but its Rx error factory " +
+                    "was not found — update CommercialBannerLoaderErrorFingerprint for this version.",
             )
-            bannerSurfaces++
-        } else {
-            println("Remove ads: commercial banner loader not present on this build; skipped")
-        }
+        commercialBannerLoaderMethod.addInstructions(
+            0,
+            """
+                new-instance v0, Ljava/lang/RuntimeException;
+                const-string v1, "Avito ads disabled"
+                invoke-direct {v0, v1}, Ljava/lang/RuntimeException;-><init>(Ljava/lang/String;)V
+                invoke-static {v0}, ${rxErrorFactory.definingClass}->${rxErrorFactory.name}(Ljava/lang/Throwable;)${rxErrorFactory.returnType}
+                move-result-object v0
+                return-object v0
+            """,
+        )
 
-        println("Remove ads: patched $bannerSurfaces banner surface(s) and $galleryTeaserConvertersPatched gallery Beduin teaser converter(s).")
+        println("Remove ads: patched 3 banner surface(s) and $galleryTeaserConvertersPatched gallery Beduin teaser converter(s) (all required).")
     }
 }

--- a/patches/src/main/kotlin/app/avito/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/avito/patches/shared/Constants.kt
@@ -29,8 +29,12 @@ internal object Constants {
                 version = "224.6",
                 minSdk = 28,
             ),
+            // Unlisted versions are best-effort: the ad patches require ad surfaces
+            // that older builds (≤ ~213) lack, so they hard-fail there. Floor verified
+            // at 221; explicit targets above are all known-good.
             AppTarget(
                 version = null,
+                isExperimental = true,
                 minSdk = 28,
             ),
         ),

--- a/patches/src/main/kotlin/app/ozon/patches/ads/RemoveOzonAdsPatch.kt
+++ b/patches/src/main/kotlin/app/ozon/patches/ads/RemoveOzonAdsPatch.kt
@@ -197,22 +197,20 @@ private val removeOzonAdResourcesPatch = resourcePatch {
     compatibleWith(COMPATIBILITY_OZON)
 
     execute {
-        var hiddenObjectGridOneLayouts = 0
-        var missingLayouts = 0
-
+        // The ad layout is mandatory: if it's gone the app changed and the patch is
+        // stale. Older builds lacking it are out of scope (we only patch current).
         try {
             document(OZON_OBJECT_GRID_ONE_LAYOUT).use { document ->
                 document.documentElement.hideWidgetRoot()
-                hiddenObjectGridOneLayouts++
             }
         } catch (_: FileNotFoundException) {
-            missingLayouts++
+            throw PatchException(
+                "Remove Ozon ads: expected ad layout not found ($OZON_OBJECT_GRID_ONE_LAYOUT) — " +
+                    "the app layout changed, update RemoveOzonAdsPatch.",
+            )
         }
 
-        println(
-            "Remove Ozon ads resources: hid $hiddenObjectGridOneLayouts object grid1 layouts, " +
-                "skipped $missingLayouts missing layouts.",
-        )
+        println("Remove Ozon ads resources: hid object grid1 layout (required surface present).")
     }
 }
 

--- a/patches/src/main/kotlin/app/tbank/patches/ads/RemoveTBankAdsPatch.kt
+++ b/patches/src/main/kotlin/app/tbank/patches/ads/RemoveTBankAdsPatch.kt
@@ -3,6 +3,7 @@ package app.tbank.patches.ads
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.tbank.patches.shared.Constants.COMPATIBILITY_TBANK
 import org.w3c.dom.Element
@@ -158,7 +159,9 @@ private val removeTBankAdResourcesPatch = resourcePatch {
         var collapsedStoryAppBars = 0
         var hiddenOfferViews = 0
         var hiddenProductViews = 0
-        var missingLayouts = 0
+        // Every ad layout is mandatory: a missing one means the app changed and the
+        // patch is stale. Older builds lacking a surface are out of scope.
+        val missing = mutableListOf<String>()
 
         storyLayoutFiles.forEach { path ->
             try {
@@ -181,7 +184,7 @@ private val removeTBankAdResourcesPatch = resourcePatch {
                         }
                 }
             } catch (_: FileNotFoundException) {
-                missingLayouts++
+                missing += path
             }
         }
 
@@ -196,7 +199,7 @@ private val removeTBankAdResourcesPatch = resourcePatch {
                         }
                 }
             } catch (_: FileNotFoundException) {
-                missingLayouts++
+                missing += path
             }
         }
 
@@ -207,16 +210,22 @@ private val removeTBankAdResourcesPatch = resourcePatch {
                     hiddenProductViews++
                 }
             } catch (_: FileNotFoundException) {
-                missingLayouts++
+                missing += path
             }
+        }
+
+        if (missing.isNotEmpty()) {
+            throw PatchException(
+                "Remove TBank ads: ${missing.size} expected ad layout(s) not found — " +
+                    "the app layout changed, update RemoveTBankAdsPatch: ${missing.joinToString(", ")}",
+            )
         }
 
         println(
             "Remove TBank ads: hid $hiddenStoryViews story views, " +
                 "collapsed $collapsedStoryAppBars story app bars, " +
                 "hid $hiddenOfferViews offer views, " +
-                "hid $hiddenProductViews product stream views, " +
-                "skipped $missingLayouts missing layouts.",
+                "hid $hiddenProductViews product stream views (all required surfaces present).",
         )
     }
 }


### PR DESCRIPTION
## Why
The ad-removal patches silently **skip** any ad surface (layout or fingerprint) that isn't present. That's the wrong default for auto-building new app versions: if an update moves or renames an ad surface, the patch quietly stops removing it and ships ads — with no signal.

## What
Make every **app-specific** ad surface **mandatory** — a missing one throws `PatchException` instead of being counted as "skipped". This trades support for older builds that legitimately lack some surfaces (out of scope — auto-builds only patch current releases) for turning "ads silently leak" into a loud, catchable build failure.

- **Avito** `Remove ads`: all ad/reward/home-banner layouts, the hero-banner widget + toolbar fingerprints, the commercial banner loader **and** its Rx error factory, and ≥1 gallery teaser converter are now required.
- **T-Bank** `Remove TBank ads`: all story/offer/product-stream ad layouts required.
- **Ozon** `Remove Ozon ads`: the object-grid ad layout required (its bytecode widgets already threw).
- **Wildberries**: already threw when no ad methods matched — unchanged.

Universal/SDK patches (telemetry, spoofing, etc.) are intentionally left tolerant — they target SDKs an app may or may not contain.

## Verification
On current builds (Avito 227 / and the latest auto-build run for each app, all reporting `skipped 0`) the patches still apply cleanly — so this is **inert today** and only fires when a surface actually disappears in a future version.