### PR TITLE
fix(avito): hide-subscriptions-tab toggle works on 226.5 + needs restart

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/Fingerprints.kt
@@ -2,6 +2,7 @@ package app.avito.patches.ui
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.string
 
 /**
  * Matches the Favorites presenter method that consumes the assembled tab list and
@@ -22,6 +23,23 @@ object FavoritesTabsConsumerFingerprint : Fingerprint(
     // of that (non-obfuscated) type rather than scanning every instruction's reference.
     filters = listOf(
         fieldAccess(type = "Lcom/avito/android/user_favorites/UserFavoritesTabsRenderMode;"),
+    ),
+)
+
+/**
+ * Cross-version fallback for builds without the 227 `UserFavoritesTabsRenderMode`
+ * consumer (e.g. 226.5). Matches the `UserFavoritesChanges(tabs, hasP2PAccess)` data
+ * class by its non-obfuscated Kotlin `toString` marker — the one place every favorites
+ * builder funnels the assembled `List<FavoritesTab>` through. The patch then hooks that
+ * class's `(List, boolean)` constructor to drop the subscriptions tab, so it works
+ * regardless of which builder path is active.
+ */
+object FavoritesChangesFingerprint : Fingerprint(
+    definingClass = "Lcom/avito/android/user_favorites/",
+    returnType = "Ljava/lang/String;",
+    parameters = emptyList(),
+    filters = listOf(
+        string("UserFavoritesChanges(tabs="),
     ),
 )
 

--- a/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
@@ -105,33 +105,59 @@ val uiTweaksPatch = bytecodePatch(
         }
 
         // --- Hide the "Подписки" (subscribed sellers) tab in Избранное ----------
-        // Replace the tab list at the entry of the presenter method that consumes
-        // it and builds the tab strip (the active path; the obvious builder A.a is
-        // bypassed by a feature flag). withoutSubscriptionsTab returns a copy with
-        // the SellersTab dropped when the toggle is on. Re-evaluated each time the
-        // Favorites screen opens, so no restart is required.
+        // Drop the SellersTab from the favorites tab list. Two entry points, tried in
+        // order so the patch spans app versions:
+        //   * 227+: the presenter consumer that reads UserFavoritesTabsRenderMode (the
+        //     active path; the obvious builder A.a is bypassed by a feature flag).
+        //   * older builds with no render-mode enum (e.g. 226.5): the
+        //     UserFavoritesChanges(List, boolean) data-class constructor that every
+        //     favorites builder funnels the assembled tab list through.
+        // withoutSubscriptionsTab returns a filtered copy when the toggle is on. The
+        // injected filter is the same in both cases — p1 is the List<FavoritesTab>.
+        // Restart-required: the assembled tab list is consumed once and the tab strip
+        // is diffed, so it won't rebind on a live settings round-trip.
+        val filterTabListInstructions = """
+            invoke-static/range { p1 .. p1 }, $MORPHE_SETTINGS_CLASS->withoutSubscriptionsTab(Ljava/util/List;)Ljava/util/List;
+            move-result-object p1
+        """
+        fun registerSubscriptionsTabToggle() = MorpheSettingsRegistry.addSwitch(
+            key = "avito_hide_subscriptions_tab",
+            title = "Скрыть вкладку «Подписки»",
+            summary = "Убрать вкладку подписок на экране Избранное",
+            default = true,
+            restartRequired = true,
+        )
+
         val tabConsumer = FavoritesTabsConsumerFingerprint.methodOrNull
-        if (tabConsumer == null) {
-            println("UI tweaks: Favorites tab consumer not found; subscriptions tab skipped")
+        val changesCtor = if (tabConsumer == null && FavoritesChangesFingerprint.methodOrNull != null) {
+            mutableClassDefBy(FavoritesChangesFingerprint.originalClassDef).methods.singleOrNull {
+                it.name == "<init>" &&
+                    it.parameterTypes.map { p -> p.toString() } == listOf("Ljava/util/List;", "Z")
+            }
         } else {
-            // p1 is the List<FavoritesTab>; swap it for the filtered copy.
-            tabConsumer.addInstructions(
-                0,
-                """
-                    invoke-static/range { p1 .. p1 }, $MORPHE_SETTINGS_CLASS->withoutSubscriptionsTab(Ljava/util/List;)Ljava/util/List;
-                    move-result-object p1
-                """,
-            )
-            MorpheSettingsRegistry.addSwitch(
-                key = "avito_hide_subscriptions_tab",
-                title = "Скрыть вкладку «Подписки»",
-                summary = "Убрать вкладку подписок на экране Избранное",
-                default = true,
-            )
-            println(
-                "UI tweaks: gated the Favorites subscriptions tab in " +
-                    "${FavoritesTabsConsumerFingerprint.originalClassDef.type}->${tabConsumer.name}",
-            )
+            null
+        }
+
+        when {
+            tabConsumer != null -> {
+                tabConsumer.addInstructions(0, filterTabListInstructions)
+                registerSubscriptionsTabToggle()
+                println(
+                    "UI tweaks: gated the Favorites subscriptions tab in " +
+                        "${FavoritesTabsConsumerFingerprint.originalClassDef.type}->${tabConsumer.name}",
+                )
+            }
+
+            changesCtor != null -> {
+                changesCtor.addInstructions(0, filterTabListInstructions)
+                registerSubscriptionsTabToggle()
+                println(
+                    "UI tweaks: gated the Favorites subscriptions tab via UserFavoritesChanges in " +
+                        "${FavoritesChangesFingerprint.originalClassDef.type}",
+                )
+            }
+
+            else -> println("UI tweaks: Favorites tab consumer not found; subscriptions tab skipped")
         }
 
         // --- Hide offer-page blocks by nulling their AdvertDetails source -------


### PR DESCRIPTION
## Problem
The **"Скрыть вкладку «Подписки»"** toggle silently went missing on **226.5** — the version the [auto-builder](https://github.com/xob0t/morphe-autobuilds) ships. Its fingerprint (`FavoritesTabsConsumerFingerprint`) matches a **227-only** consumer that reads the `UserFavoritesTabsRenderMode` enum, which doesn't exist on 226.5, so the patch skipped and never registered the toggle.

## Fix
Add a cross-version fallback. `FavoritesChangesFingerprint` locates the `UserFavoritesChanges(List<FavoritesTab>, boolean)` data class by its non-obfuscated Kotlin `toString` marker (`"UserFavoritesChanges(tabs="`, present on **both** 226.5 and 227), and the patch hooks **that class's constructor** — the single funnel every favorites builder routes the assembled tab list through — applying the same `withoutSubscriptionsTab` filter.

- **227 unchanged**: the fallback only runs when the primary consumer fingerprint doesn't match.
- Also mark the toggle **`restartRequired`**: the tab list is consumed once and the strip is diffed, so it won't rebind on a live settings round-trip.

## Verified on device (226.5)
Patch applies (hooks the `UserFavoritesChanges` constructor), app runs (the constructor-before-`super` injection is verifier-safe), the toggle appears in Настройки Morphe, and the «Подписки» tab is removed when the toggle is on.