### PR TITLE
feat(avito): enable Block listings and UI tweaks by default

### DIFF
--- a/patches/src/main/kotlin/app/avito/patches/blacklist/BlockListingsPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/blacklist/BlockListingsPatch.kt
@@ -62,7 +62,7 @@ val blockListingsPatch = bytecodePatch(
     name = "Block listings",
     description = "Hides Avito offers from blacklisted adverts or sellers and adds a blacklist manager " +
         "(import/export compatible with the Ave Blacklist extension).",
-    default = false,
+    default = true,
 ) {
     compatibleWith(COMPATIBILITY_AVITO)
     // morpheSettingsPatch provides the shared extension + the Settings host this

--- a/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
+++ b/patches/src/main/kotlin/app/avito/patches/ui/UiTweaksPatch.kt
@@ -59,7 +59,7 @@ val uiTweaksPatch = bytecodePatch(
         "categories, hide the \"Подписки\" tab in Избранное, hide installments (Рассрочка) and the " +
         "\"Спросите у продавца\" block on offers, expand descriptions by default (no \"Читать далее\"), " +
         "and hide the Avi assistant tab in the bottom navigation.",
-    default = false,
+    default = true,
 ) {
     compatibleWith(COMPATIBILITY_AVITO)
     dependsOn(morpheSettingsPatch)


### PR DESCRIPTION
## What

Flip **Block listings** and **UI tweaks** to `default = true`.

## Why

A default patch selection only ran telemetry/updates/ads (`patches=3`), so the **Настройки Morphe** host showed a single toggle (`avito_disable_updates`) — the registry is built at patch time from whichever patches execute. The blacklist manager and the UI-tweak toggles (incl. hide-subscriptions-tab) only register when their patches run, so users had to enable them manually to see them.

## Notes

- `Morphe settings` itself stays `default = false` — it rides along as a dependency.
- **AMOLED dark theme** stays opt-in (more opinionated visual change).
- Version-skew safe for the autobuild's 226.5 target: Block listings uses the structural konveyor fingerprint (213–227); UI tweaks has the 226.5/227 subscriptions fallback.